### PR TITLE
DifferenceWith - Fixing the array position that output items are placed in

### DIFF
--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -30,7 +30,7 @@ module.exports = _curry3(function differenceWith(pred, first, second) {
   var containsPred = containsWith(pred);
   while (++idx < firstLen) {
     if (!containsPred(first[idx], second) && !containsPred(first[idx], out)) {
-      out[idx] = first[idx];
+      out[out.length] = first[idx];
     }
   }
   return out;


### PR DESCRIPTION
The current behaviour places items at there original position in the input array giving a sparse array.  Previously differenceWith gave a compact array.

First pull request! - apologies if I've mucked it up in any way
